### PR TITLE
Add /v1/orders/ordersuser endpoint for customer order retrieval

### DIFF
--- a/src/main/kotlin/ru/sogaz/site/orderingService/config/ServiceConfig.kt
+++ b/src/main/kotlin/ru/sogaz/site/orderingService/config/ServiceConfig.kt
@@ -10,9 +10,11 @@ import ru.sogaz.site.orderingService.mappers.OrderMapper
 import ru.sogaz.site.orderingService.mappers.PaymentEventMapper
 import ru.sogaz.site.orderingService.properties.RabbitProps
 import ru.sogaz.site.orderingService.service.BuildBatchConsumerService
+import ru.sogaz.site.orderingService.service.OrdersUserService
 import ru.sogaz.site.orderingService.service.OrderBatchConsumer
 import ru.sogaz.site.orderingService.service.PaymentEventProducer
 import ru.sogaz.site.orderingService.service.impl.BuildBatchConsumerServiceImpl
+import ru.sogaz.site.orderingService.service.impl.OrdersUserServiceImpl
 import ru.sogaz.site.orderingService.service.impl.OrderBatchConsumerImpl
 import ru.sogaz.site.orderingService.service.impl.PaymentEventProducerImpl
 
@@ -51,4 +53,13 @@ class ServiceConfig {
         rabbit: RabbitTemplate,
         props: RabbitProps,
     ): PaymentEventProducer = PaymentEventProducerImpl(rabbit = rabbit, props = props)
+
+    @Bean
+    fun ordersUserService(
+        orderDao: OrderDao,
+        subOrderDao: SubOrderDao,
+    ): OrdersUserService = OrdersUserServiceImpl(
+        orderDao = orderDao,
+        subOrderDao = subOrderDao,
+    )
 }

--- a/src/main/kotlin/ru/sogaz/site/orderingService/controller/ordersuser/OrdersUserController.kt
+++ b/src/main/kotlin/ru/sogaz/site/orderingService/controller/ordersuser/OrdersUserController.kt
@@ -1,0 +1,25 @@
+package ru.sogaz.site.orderingService.controller.ordersuser
+
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import ru.sogaz.site.orderingService.service.OrdersUserService
+
+@RestController
+@RequestMapping("/v1/orders")
+class OrdersUserController(
+    private val ordersUserService: OrdersUserService,
+) {
+    @PostMapping("/ordersuser")
+    fun getOrders(
+        @RequestHeader("TraceId") traceId: String,
+        @RequestHeader("Autorization") _: String,
+        @RequestBody request: OrdersUserRequest,
+    ): ResponseEntity<OrdersUserResponse> {
+        val result = ordersUserService.getOrders(traceId, request)
+        return ResponseEntity.status(result.httpStatus).body(result.body)
+    }
+}

--- a/src/main/kotlin/ru/sogaz/site/orderingService/controller/ordersuser/OrdersUserRequest.kt
+++ b/src/main/kotlin/ru/sogaz/site/orderingService/controller/ordersuser/OrdersUserRequest.kt
@@ -1,0 +1,14 @@
+package ru.sogaz.site.orderingService.controller.ordersuser
+
+import com.fasterxml.jackson.annotation.JsonInclude
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class OrdersUserRequest(
+    val status: String?,
+    val searchName: String?,
+    val userId: String?,
+    val gdId: String?,
+    val email: String?,
+    val phone: String?,
+    val condition: String?,
+)

--- a/src/main/kotlin/ru/sogaz/site/orderingService/controller/ordersuser/OrdersUserResponse.kt
+++ b/src/main/kotlin/ru/sogaz/site/orderingService/controller/ordersuser/OrdersUserResponse.kt
@@ -1,0 +1,46 @@
+package ru.sogaz.site.orderingService.controller.ordersuser
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class OrdersUserResponse(
+    val status: String,
+    val code: Int,
+    val traceId: String,
+    val innerError: String?,
+    val messageError: String?,
+    val errorsValidate: List<ValidationErrorDto>?,
+    val data: OrdersUserData?,
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class OrdersUserData(
+    val ordersList: List<OrdersUserOrderDto>,
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class OrdersUserOrderDto(
+    val orderId: String,
+    val premiumAmount: String,
+    val subOrdersList: List<OrdersUserSubOrderDto>,
+)
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class OrdersUserSubOrderDto(
+    @JsonProperty("policy_id")
+    val policyId: String?,
+    @JsonProperty("policy_number")
+    val policyNumber: String?,
+    @JsonProperty("type_insurance")
+    val typeInsurance: String?,
+    @JsonProperty("insurance_program")
+    val insuranceProgram: String?,
+    @JsonProperty("premium_amount")
+    val premiumAmount: String,
+)
+
+data class ValidationErrorDto(
+    val param: String,
+    val error: String,
+)

--- a/src/main/kotlin/ru/sogaz/site/orderingService/dao/OrderDao.kt
+++ b/src/main/kotlin/ru/sogaz/site/orderingService/dao/OrderDao.kt
@@ -1,7 +1,11 @@
 package ru.sogaz.site.orderingService.dao
 
+import ru.sogaz.site.orderingService.dao.model.OrderSummary
+import ru.sogaz.site.orderingService.dao.model.OrdersUserSearchFilter
 import ru.sogaz.site.orderingService.entity.OrderEntity
 
 interface OrderDao {
     fun upsertOrders(orders: List<OrderEntity>)
+
+    fun findOrdersBySearch(filter: OrdersUserSearchFilter): List<OrderSummary>
 }

--- a/src/main/kotlin/ru/sogaz/site/orderingService/dao/SubOrderDao.kt
+++ b/src/main/kotlin/ru/sogaz/site/orderingService/dao/SubOrderDao.kt
@@ -1,7 +1,11 @@
 package ru.sogaz.site.orderingService.dao
 
+import ru.sogaz.site.orderingService.dao.model.SubOrderSummary
 import ru.sogaz.site.orderingService.entity.SubOrderEntity
+import java.util.UUID
 
 interface SubOrderDao {
     fun upsertSubOrders(subs: List<SubOrderEntity>)
+
+    fun findSubOrdersByOrderIds(orderIds: Collection<UUID>): List<SubOrderSummary>
 }

--- a/src/main/kotlin/ru/sogaz/site/orderingService/dao/impl/OrderDaoImpl.kt
+++ b/src/main/kotlin/ru/sogaz/site/orderingService/dao/impl/OrderDaoImpl.kt
@@ -2,9 +2,15 @@ package ru.sogaz.site.orderingService.dao.impl
 
 import org.springframework.jdbc.core.JdbcTemplate
 import ru.sogaz.site.orderingService.dao.OrderDao
+import ru.sogaz.site.orderingService.dao.model.OrderSummary
+import ru.sogaz.site.orderingService.dao.model.OrdersUserContactCondition
+import ru.sogaz.site.orderingService.dao.model.OrdersUserSearchFilter
+import ru.sogaz.site.orderingService.dao.model.OrdersUserSearchType
 import ru.sogaz.site.orderingService.entity.OrderEntity
+import ru.sogaz.site.orderingService.enums.OrderStatusesEnum
 import ru.sogaz.site.orderingService.loggerFor
 import java.sql.Timestamp
+import java.util.UUID
 
 class OrderDaoImpl(
     private val jdbcTemplate: JdbcTemplate,
@@ -57,5 +63,70 @@ class OrderDaoImpl(
 
         logger.info(LOG_EXECUTE.format(orders.size))
         logger.info(LOG_DONE.format(orders.size))
+    }
+
+    override fun findOrdersBySearch(filter: OrdersUserSearchFilter): List<OrderSummary> {
+        val (whereClause, params) = buildWhereClause(filter)
+
+        val sql =
+            """
+            SELECT o.order_id, o.premium_amount, o.status
+            FROM orders o
+            WHERE $whereClause
+            ORDER BY o.create_date DESC
+            """.trimIndent()
+
+        return jdbcTemplate.query(sql, params.toTypedArray()) { rs, _ ->
+            OrderSummary(
+                orderId = rs.getObject("order_id", UUID::class.java),
+                premiumAmount = rs.getBigDecimal("premium_amount"),
+                status = rs.getString("status")
+                    ?.let { OrderStatusesEnum.valueOf(it) }
+                    ?: OrderStatusesEnum.NEW,
+            )
+        }
+    }
+
+    private fun buildWhereClause(filter: OrdersUserSearchFilter): Pair<String, List<Any?>> {
+        return when (filter.type) {
+            OrdersUserSearchType.USER_ID ->
+                "o.recipient_user_id = ?" to listOf(filter.userId)
+
+            OrdersUserSearchType.GD_ID ->
+                "o.recipient_user_gd_id = ?" to listOf(filter.gdId)
+
+            OrdersUserSearchType.EMAIL_OR_PHONE -> buildEmailPhoneClause(filter)
+        }
+    }
+
+    private fun buildEmailPhoneClause(filter: OrdersUserSearchFilter): Pair<String, List<Any?>> {
+        return when (filter.contactCondition) {
+            OrdersUserContactCondition.AND ->
+                "o.recipient_email = ? AND o.recipient_phone = ?" to listOf(filter.email, filter.phone)
+
+            OrdersUserContactCondition.OR -> {
+                val conditions = mutableListOf<String>()
+                val params = mutableListOf<Any?>()
+
+                filter.email?.let {
+                    conditions += "o.recipient_email = ?"
+                    params += it
+                }
+
+                filter.phone?.let {
+                    conditions += "o.recipient_phone = ?"
+                    params += it
+                }
+
+                if (conditions.isEmpty()) {
+                    "(1 = 0)" to emptyList()
+                } else {
+                    "(${conditions.joinToString(" OR ")})" to params
+                }
+            }
+
+            null ->
+                "(1 = 0)" to emptyList()
+        }
     }
 }

--- a/src/main/kotlin/ru/sogaz/site/orderingService/dao/impl/SubOrderDaoImpl.kt
+++ b/src/main/kotlin/ru/sogaz/site/orderingService/dao/impl/SubOrderDaoImpl.kt
@@ -2,8 +2,10 @@ package ru.sogaz.site.orderingService.dao.impl
 
 import org.springframework.jdbc.core.JdbcTemplate
 import ru.sogaz.site.orderingService.dao.SubOrderDao
+import ru.sogaz.site.orderingService.dao.model.SubOrderSummary
 import ru.sogaz.site.orderingService.entity.SubOrderEntity
 import ru.sogaz.site.orderingService.loggerFor
+import java.util.UUID
 
 class SubOrderDaoImpl(
     private val jdbcTemplate: JdbcTemplate,
@@ -52,5 +54,30 @@ class SubOrderDaoImpl(
 
         logger.info(LOG_EXECUTE.format(subs.size))
         logger.info(LOG_DONE.format(subs.size))
+    }
+
+    override fun findSubOrdersByOrderIds(orderIds: Collection<UUID>): List<SubOrderSummary> {
+        if (orderIds.isEmpty()) {
+            return emptyList()
+        }
+
+        val placeholders = orderIds.joinToString(",") { "?" }
+        val sql =
+            """
+            SELECT order_id, policy_id, policy_number, type_insurance, insurance_program, premium_amount
+            FROM sub_orders
+            WHERE order_id IN ($placeholders)
+            """.trimIndent()
+
+        return jdbcTemplate.query(sql, orderIds.toTypedArray()) { rs, _ ->
+            SubOrderSummary(
+                orderId = rs.getObject("order_id", UUID::class.java),
+                policyId = rs.getString("policy_id"),
+                policyNumber = rs.getString("policy_number"),
+                typeInsurance = rs.getString("type_insurance"),
+                insuranceProgram = rs.getString("insurance_program"),
+                premiumAmount = rs.getBigDecimal("premium_amount"),
+            )
+        }
     }
 }

--- a/src/main/kotlin/ru/sogaz/site/orderingService/dao/model/OrdersUserSearchModels.kt
+++ b/src/main/kotlin/ru/sogaz/site/orderingService/dao/model/OrdersUserSearchModels.kt
@@ -1,0 +1,40 @@
+package ru.sogaz.site.orderingService.dao.model
+
+import ru.sogaz.site.orderingService.enums.OrderStatusesEnum
+import java.math.BigDecimal
+import java.util.UUID
+
+data class OrdersUserSearchFilter(
+    val type: OrdersUserSearchType,
+    val userId: String? = null,
+    val gdId: String? = null,
+    val email: String? = null,
+    val phone: String? = null,
+    val contactCondition: OrdersUserContactCondition? = null,
+)
+
+enum class OrdersUserSearchType {
+    USER_ID,
+    GD_ID,
+    EMAIL_OR_PHONE,
+}
+
+enum class OrdersUserContactCondition {
+    OR,
+    AND,
+}
+
+data class OrderSummary(
+    val orderId: UUID,
+    val premiumAmount: BigDecimal?,
+    val status: OrderStatusesEnum,
+)
+
+data class SubOrderSummary(
+    val orderId: UUID,
+    val policyId: String?,
+    val policyNumber: String?,
+    val typeInsurance: String?,
+    val insuranceProgram: String?,
+    val premiumAmount: BigDecimal?,
+)

--- a/src/main/kotlin/ru/sogaz/site/orderingService/service/OrdersUserService.kt
+++ b/src/main/kotlin/ru/sogaz/site/orderingService/service/OrdersUserService.kt
@@ -1,0 +1,14 @@
+package ru.sogaz.site.orderingService.service
+
+import org.springframework.http.HttpStatus
+import ru.sogaz.site.orderingService.controller.ordersuser.OrdersUserRequest
+import ru.sogaz.site.orderingService.controller.ordersuser.OrdersUserResponse
+
+data class OrdersUserServiceResult(
+    val httpStatus: HttpStatus,
+    val body: OrdersUserResponse,
+)
+
+interface OrdersUserService {
+    fun getOrders(traceId: String, request: OrdersUserRequest): OrdersUserServiceResult
+}

--- a/src/main/kotlin/ru/sogaz/site/orderingService/service/impl/OrdersUserServiceImpl.kt
+++ b/src/main/kotlin/ru/sogaz/site/orderingService/service/impl/OrdersUserServiceImpl.kt
@@ -1,0 +1,317 @@
+package ru.sogaz.site.orderingService.service.impl
+
+import org.springframework.http.HttpStatus
+import ru.sogaz.site.orderingService.controller.ordersuser.OrdersUserData
+import ru.sogaz.site.orderingService.controller.ordersuser.OrdersUserOrderDto
+import ru.sogaz.site.orderingService.controller.ordersuser.OrdersUserRequest
+import ru.sogaz.site.orderingService.controller.ordersuser.OrdersUserResponse
+import ru.sogaz.site.orderingService.controller.ordersuser.OrdersUserSubOrderDto
+import ru.sogaz.site.orderingService.controller.ordersuser.ValidationErrorDto
+import ru.sogaz.site.orderingService.dao.OrderDao
+import ru.sogaz.site.orderingService.dao.SubOrderDao
+import ru.sogaz.site.orderingService.dao.model.OrderSummary
+import ru.sogaz.site.orderingService.dao.model.OrdersUserContactCondition
+import ru.sogaz.site.orderingService.dao.model.OrdersUserSearchFilter
+import ru.sogaz.site.orderingService.dao.model.OrdersUserSearchType
+import ru.sogaz.site.orderingService.enums.OrderStatusesEnum
+import ru.sogaz.site.orderingService.loggerFor
+import ru.sogaz.site.orderingService.service.OrdersUserService
+import ru.sogaz.site.orderingService.service.OrdersUserServiceResult
+import java.math.BigDecimal
+
+class OrdersUserServiceImpl(
+    private val orderDao: OrderDao,
+    private val subOrderDao: SubOrderDao,
+) : OrdersUserService {
+    companion object {
+        private const val STATUS_SUCCESS = "success"
+        private const val STATUS_ERROR = "error"
+        private const val SUCCESS_CODE = 1101200
+        private const val VALIDATION_ERROR_CODE = -1101640422
+        private const val CONFLICT_ERROR_CODE = -1101409
+        private const val INNER_ERROR_CONFLICT = "Conflict"
+        private const val INNER_ERROR_VALIDATION = "UnprocessableEntity"
+        private const val MESSAGE_VALIDATION = "Не все обязательные данные указаны корректно"
+        private const val MESSAGE_CLIENT_NOT_FOUND =
+            "Ошибка получения списка заказов клиента. Клиент с такими данными не найден"
+        private const val MESSAGE_ORDERS_NOT_FOUND =
+            "Ошибка получения списка заказов клиента. Заказы с указанными статусами не найдены"
+        private val EMAIL_REGEX =
+            Regex("^[A-Za-z0-9.!#\$%&'*+/=?^_`{|}~-]+@[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?(?:\\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+$")
+        private val PHONE_REGEX = Regex("^\\+?[0-9 ]+$")
+    }
+
+    private val logger = loggerFor(javaClass)
+
+    override fun getOrders(traceId: String, request: OrdersUserRequest): OrdersUserServiceResult {
+        val validation = validateRequest(request)
+
+        if (validation.errors.isNotEmpty()) {
+            logger.info("Валидация запроса завершена с ошибками: {}", validation.errors)
+            return OrdersUserServiceResult(
+                httpStatus = HttpStatus.UNPROCESSABLE_ENTITY,
+                body = OrdersUserResponse(
+                    status = STATUS_ERROR,
+                    code = VALIDATION_ERROR_CODE,
+                    traceId = traceId,
+                    innerError = INNER_ERROR_VALIDATION,
+                    messageError = MESSAGE_VALIDATION,
+                    errorsValidate = validation.errors,
+                    data = null,
+                ),
+            )
+        }
+
+        val valid = validation.validated ?: return OrdersUserServiceResult(
+            httpStatus = HttpStatus.UNPROCESSABLE_ENTITY,
+            body = OrdersUserResponse(
+                status = STATUS_ERROR,
+                code = VALIDATION_ERROR_CODE,
+                traceId = traceId,
+                innerError = INNER_ERROR_VALIDATION,
+                messageError = MESSAGE_VALIDATION,
+                errorsValidate = validation.errors,
+                data = null,
+            ),
+        )
+
+        val orders = orderDao.findOrdersBySearch(valid.toSearchFilter())
+        if (orders.isEmpty()) {
+            logger.info("Клиент по параметрам {} не найден", valid.searchType)
+            return buildConflictResponse(traceId, MESSAGE_CLIENT_NOT_FOUND)
+        }
+
+        val filteredOrders = filterByStatus(valid.status, orders)
+        if (filteredOrders.isEmpty()) {
+            logger.info("Для клиента {} не найдено заказов по статусу {}", valid.searchType, valid.status)
+            return buildConflictResponse(traceId, MESSAGE_ORDERS_NOT_FOUND)
+        }
+
+        val orderIds = filteredOrders.map { it.orderId }
+        val subOrders = subOrderDao.findSubOrdersByOrderIds(orderIds).groupBy { it.orderId }
+
+        val ordersList = filteredOrders.map { order ->
+            OrdersUserOrderDto(
+                orderId = order.orderId.toString(),
+                premiumAmount = order.premiumAmount.toAmountString(),
+                subOrdersList = subOrders[order.orderId].orEmpty().map {
+                    OrdersUserSubOrderDto(
+                        policyId = it.policyId,
+                        policyNumber = it.policyNumber,
+                        typeInsurance = it.typeInsurance,
+                        insuranceProgram = it.insuranceProgram,
+                        premiumAmount = it.premiumAmount.toAmountString(),
+                    )
+                },
+            )
+        }
+
+        return OrdersUserServiceResult(
+            httpStatus = HttpStatus.OK,
+            body = OrdersUserResponse(
+                status = STATUS_SUCCESS,
+                code = SUCCESS_CODE,
+                traceId = traceId,
+                innerError = null,
+                messageError = null,
+                errorsValidate = null,
+                data = OrdersUserData(ordersList = ordersList),
+            ),
+        )
+    }
+
+    private fun buildConflictResponse(traceId: String, message: String) =
+        OrdersUserServiceResult(
+            httpStatus = HttpStatus.CONFLICT,
+            body = OrdersUserResponse(
+                status = STATUS_ERROR,
+                code = CONFLICT_ERROR_CODE,
+                traceId = traceId,
+                innerError = INNER_ERROR_CONFLICT,
+                messageError = message,
+                errorsValidate = null,
+                data = null,
+            ),
+        )
+
+    private fun filterByStatus(status: OrdersUserStatus, orders: List<OrderSummary>): List<OrderSummary> =
+        when (status) {
+            OrdersUserStatus.UNPAID ->
+                orders.filter { it.status == OrderStatusesEnum.NEW || it.status == OrderStatusesEnum.UPDATE }
+
+            OrdersUserStatus.PAID ->
+                orders.filter { it.status == OrderStatusesEnum.SUCCESS }
+
+            OrdersUserStatus.ALL -> orders
+        }
+
+    private fun validateRequest(request: OrdersUserRequest): ValidationOutcome {
+        val errors = mutableListOf<ValidationErrorDto>()
+
+        val status = request.status.normalize()
+        val statusEnum = status?.let { OrdersUserStatus.from(it) }
+        if (status == null) {
+            errors += ValidationErrorDto(param = "status", error = REQUIRED_VALUE)
+        } else if (statusEnum == null) {
+            errors += ValidationErrorDto(param = "status", error = "Возможные значения - unpaid, paid или all")
+        }
+
+        val searchName = request.searchName.normalize()
+        val searchType = searchName?.let { OrdersUserSearchTypeExt.from(it) }
+        if (searchName == null) {
+            errors += ValidationErrorDto(param = "searchName", error = REQUIRED_VALUE)
+        } else if (searchType == null) {
+            errors += ValidationErrorDto(param = "searchName", error = "Указан недопустимый параметр поиска")
+        }
+
+        val normalizedUserId = request.userId.normalize()
+        val normalizedGdId = request.gdId.normalize()
+        val normalizedEmail = request.email.normalize()
+        val normalizedPhone = request.phone.normalize()
+        val normalizedCondition = request.condition.normalize()
+
+        var contactCondition: OrdersUserContactCondition? = null
+
+        when (searchType) {
+            OrdersUserSearchType.USER_ID -> {
+                if (normalizedUserId == null) {
+                    errors += ValidationErrorDto(param = "userId", error = REQUIRED_VALUE)
+                }
+            }
+
+            OrdersUserSearchType.GD_ID -> {
+                if (normalizedGdId == null) {
+                    errors += ValidationErrorDto(param = "gdId", error = REQUIRED_VALUE)
+                }
+            }
+
+            OrdersUserSearchType.EMAIL_OR_PHONE -> {
+                contactCondition = normalizedCondition?.let { OrdersUserContactConditionExt.from(it) }
+                if (normalizedCondition == null) {
+                    errors += ValidationErrorDto(param = "condition", error = REQUIRED_VALUE)
+                } else if (contactCondition == null) {
+                    errors += ValidationErrorDto(param = "condition", error = "Возможные значения - or и and")
+                }
+
+                when (contactCondition) {
+                    OrdersUserContactCondition.AND -> {
+                        if (normalizedEmail == null) {
+                            errors += ValidationErrorDto(param = "email", error = REQUIRED_VALUE)
+                        }
+                        if (normalizedPhone == null) {
+                            errors += ValidationErrorDto(param = "phone", error = REQUIRED_VALUE)
+                        }
+                    }
+
+                    OrdersUserContactCondition.OR -> {
+                        if (normalizedEmail == null && normalizedPhone == null) {
+                            errors += ValidationErrorDto(param = "email", error = REQUIRED_VALUE)
+                            errors += ValidationErrorDto(param = "phone", error = REQUIRED_VALUE)
+                        }
+                    }
+
+                    null -> {}
+                }
+
+                normalizedEmail?.let {
+                    if (!EMAIL_REGEX.matches(it)) {
+                        errors += ValidationErrorDto(
+                            param = "email",
+                            error = "Значение должно содержать латинские буквы, цифры и специальные символы",
+                        )
+                    }
+                }
+
+                normalizedPhone?.let {
+                    if (!PHONE_REGEX.matches(it)) {
+                        errors += ValidationErrorDto(
+                            param = "phone",
+                            error = "Значение должно содержать только цифры, пробел и +",
+                        )
+                    }
+                }
+            }
+
+            null -> {}
+        }
+
+        if (errors.isNotEmpty()) {
+            return ValidationOutcome(errors = errors)
+        }
+
+        val validated = OrdersUserValidatedRequest(
+            status = statusEnum!!,
+            searchType = searchType!!,
+            userId = normalizedUserId,
+            gdId = normalizedGdId,
+            email = normalizedEmail,
+            phone = normalizedPhone,
+            condition = contactCondition,
+        )
+
+        return ValidationOutcome(errors = emptyList(), validated = validated)
+    }
+
+    private data class ValidationOutcome(
+        val errors: List<ValidationErrorDto>,
+        val validated: OrdersUserValidatedRequest? = null,
+    )
+
+    private data class OrdersUserValidatedRequest(
+        val status: OrdersUserStatus,
+        val searchType: OrdersUserSearchType,
+        val userId: String?,
+        val gdId: String?,
+        val email: String?,
+        val phone: String?,
+        val condition: OrdersUserContactCondition?,
+    ) {
+        fun toSearchFilter() =
+            OrdersUserSearchFilter(
+                type = searchType,
+                userId = userId,
+                gdId = gdId,
+                email = email,
+                phone = phone,
+                contactCondition = condition,
+            )
+    }
+
+    private enum class OrdersUserStatus(val value: String) {
+        UNPAID("unpaid"),
+        PAID("paid"),
+        ALL("all");
+
+        companion object {
+            fun from(value: String) = entries.firstOrNull { it.value.equals(value, ignoreCase = true) }
+        }
+    }
+
+    private object OrdersUserSearchTypeExt {
+        fun from(value: String) =
+            when {
+                value.equals("userId", ignoreCase = true) -> OrdersUserSearchType.USER_ID
+                value.equals("gdId", ignoreCase = true) -> OrdersUserSearchType.GD_ID
+                value.equals("emailOrPhone", ignoreCase = true) -> OrdersUserSearchType.EMAIL_OR_PHONE
+                else -> null
+            }
+    }
+
+    private object OrdersUserContactConditionExt {
+        fun from(value: String) =
+            when {
+                value.equals("or", ignoreCase = true) -> OrdersUserContactCondition.OR
+                value.equals("and", ignoreCase = true) -> OrdersUserContactCondition.AND
+                else -> null
+            }
+    }
+
+    private fun String?.normalize() = this?.trim()?.takeIf { it.isNotEmpty() }
+
+    private fun BigDecimal?.toAmountString(): String =
+        this?.stripTrailingZeros()?.toPlainString() ?: ""
+
+    private companion object {
+        private const val REQUIRED_VALUE = "Не заполнено обязательное значение"
+    }
+}


### PR DESCRIPTION
## Summary
- add controller and transport models for the POST /v1/orders/ordersuser endpoint
- implement service logic with request validation, status filtering, and response assembly
- extend the data layer to query orders and related sub-orders and register the service bean

## Testing
- mvn -q -DskipTests package *(fails: missing ru.sogaz.esb.core:logger:jar:3.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68e3d4addda88327a2ecf5f8d225c723